### PR TITLE
ci: update checkout step to use pull request base reference

### DIFF
--- a/.github/workflows/deloyment_on_render_staging.yml
+++ b/.github/workflows/deloyment_on_render_staging.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.base.ref }}
 
     - name: Deploy to Render
       env:

--- a/.github/workflows/deloyment_on_render_staging.yml
+++ b/.github/workflows/deloyment_on_render_staging.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.ref }}
 
     - name: Deploy to Render
       env:

--- a/.github/workflows/deployment_on_render_development.yml
+++ b/.github/workflows/deployment_on_render_development.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.base.ref }}
+        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Deploy to Render
       env:

--- a/.github/workflows/deployment_on_render_development.yml
+++ b/.github/workflows/deployment_on_render_development.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.ref }}
 
     - name: Deploy to Render
       env:


### PR DESCRIPTION
When deploying it always takes the latest main ref. It should take the Pull Request latest commit ref instead.